### PR TITLE
Update to the latest version + a couple of other improvements

### DIFF
--- a/gg.tesseract.Tesseract.metainfo.xml
+++ b/gg.tesseract.Tesseract.metainfo.xml
@@ -24,8 +24,8 @@ shading and morphological/temporal/multisample anti-aliasing.</p>
   <releases>
     <release version="2024-04-25" date="2024-04-25" type="stable"/>
   </releases>
-  <url type="homepage">https://tesseract.gg/</url>
-  <url type="bugtracker">https://tesseract.gg/forum/viewforum.php?id=7</url>
+  <url type="homepage">http://tesseract.gg/</url>
+  <url type="bugtracker">http://tesseract.gg/forum/viewforum.php?id=7</url>
   <url type="vcs-browser">https://websvn.tuxfamily.org/tesseract/main/</url>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-realistic">moderate</content_attribute>

--- a/gg.tesseract.Tesseract.metainfo.xml
+++ b/gg.tesseract.Tesseract.metainfo.xml
@@ -1,7 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
-<component type="desktop">
+<component type="desktop-application">
   <!--Created with jdAppStreamEdit 7.0-->
   <id>gg.tesseract.Tesseract</id>
+  <launchable type="desktop-id">gg.tesseract.Tesseract.desktop</launchable>
   <name>Tesseract</name>
   <summary>First-person shooter with cooperative in-game map editing</summary>
   <developer_name>Lee Salzmann</developer_name>
@@ -17,14 +18,15 @@ shading and morphological/temporal/multisample anti-aliasing.</p>
   <screenshots>
     <screenshot type="default">
       <image type="source">https://libregamewiki.org/images/1/14/Tesseract_FPS.jpg</image>
+      <caption>Gameplay on the map complex</caption>
     </screenshot>
   </screenshots>
   <releases>
     <release version="2024-04-25" date="2024-04-25" type="stable"/>
   </releases>
-  <url type="homepage">http://tesseract.gg/</url>
-  <url type="bugtracker">http://tesseract.gg/forum/viewforum.php?id=7</url>
-  <url type="vcs-browser">http://websvn.tuxfamily.org/tesseract/main/</url>
+  <url type="homepage">https://tesseract.gg/</url>
+  <url type="bugtracker">https://tesseract.gg/forum/viewforum.php?id=7</url>
+  <url type="vcs-browser">https://websvn.tuxfamily.org/tesseract/main/</url>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-realistic">moderate</content_attribute>
     <content_attribute id="social-chat">intense</content_attribute>

--- a/gg.tesseract.Tesseract.metainfo.xml
+++ b/gg.tesseract.Tesseract.metainfo.xml
@@ -20,7 +20,7 @@ shading and morphological/temporal/multisample anti-aliasing.</p>
     </screenshot>
   </screenshots>
   <releases>
-    <release version="2014-05-12" date="2014-05-12" type="stable"/>
+    <release version="2024-04-25" date="2024-04-25" type="stable"/>
   </releases>
   <url type="homepage">http://tesseract.gg/</url>
   <url type="bugtracker">http://tesseract.gg/forum/viewforum.php?id=7</url>

--- a/gg.tesseract.Tesseract.yaml
+++ b/gg.tesseract.Tesseract.yaml
@@ -1,11 +1,12 @@
 app-id: gg.tesseract.Tesseract
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: tesseract
 finish-args:
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --share=ipc
   - --share=network
   - --device=dri
@@ -26,7 +27,7 @@ modules:
     sources:
       - type: svn
         url: svn://svn.tuxfamily.org/svnroot/tesseract/main
-        revision: 2549
+        revision: 2553
       - type: shell
         commands:
           - sed -i 's#TESS_DATA=.#TESS_DATA=/app/lib/tesseract/#g' tesseract_unix


### PR DESCRIPTION
- Update game to version 2024-04-25 (Rev 2553)

- Bump runtime to 24.08

- Switch to Wayland by default: Some other SDL2 based games on Flathub like Xonotic and Red Eclipse have already switched to Wayland by default. I've also tried Tesseract locally natively on Wayland and it works well.