### PR TITLE
Make sure only the upstream specified compile flags are used

### DIFF
--- a/gg.tesseract.Tesseract.metainfo.xml
+++ b/gg.tesseract.Tesseract.metainfo.xml
@@ -18,7 +18,7 @@ shading and morphological/temporal/multisample anti-aliasing.</p>
   <screenshots>
     <screenshot type="default">
       <image type="source">https://libregamewiki.org/images/1/14/Tesseract_FPS.jpg</image>
-      <caption>Gameplay on the map complex</caption>
+      <caption>Gameplay on the map Complex</caption>
     </screenshot>
   </screenshots>
   <releases>

--- a/gg.tesseract.Tesseract.yaml
+++ b/gg.tesseract.Tesseract.yaml
@@ -15,7 +15,6 @@ finish-args:
 modules:
   - name: tesseract
     no-autogen: true
-    no-make-install: true
     build-options:
       cflags: -O3 -fomit-frame-pointer
       cflags-override: true

--- a/gg.tesseract.Tesseract.yaml
+++ b/gg.tesseract.Tesseract.yaml
@@ -14,8 +14,13 @@ finish-args:
 
 modules:
   - name: tesseract
-    buildsystem: autotools
     no-autogen: true
+    no-make-install: true
+    build-options:
+      cflags: -O3 -fomit-frame-pointer
+      cflags-override: true
+      cxxflags: -O3 -fomit-frame-pointer -ffast-math
+      cxxflags-override: true
     subdir: src
     post-install:
       - mkdir -p ${FLATPAK_DEST}/lib/tesseract


### PR DESCRIPTION
I've noticed that Flathub's buildsystems tend to ignore the primary compile flags that are specified in the upstream makefile (in this case -O3, -fomit-frame-pointer, etc) and completely replace them with FD SDK's default flags, including those that potentially hurt performance like -fno-omit-frame-pointer. This change makes sure that only the upstream specified flags are used.
The cxxflags are set accordingly to the game's makefile, while the cflags are set accordingly to the bundled enet library makefile.
Note that I changed the buildsystem because the default one outputs better logs imo and it's more clear about which compile flags exactly are used.

I maintain another game which is built on a similar game engine by the same dev, so after I made this change there, I've noticed faster loading times and lower cpu usage.

I also wanted to check if the svn source url still works, because Tuxfamily seems to have a lot of issues lately.